### PR TITLE
Phase 2: Entity Layer — NPCs, enemies, items, and interactive objects

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
         <canvas id="gameCanvas"></canvas>
         <div id="game-info">
             <span id="board-name"></span>
+            <span id="health-display">Health: 3/3</span>
             <span>Crystals: <span id="crystal-count">0</span></span>
         </div>
     </div>

--- a/public/levels/world.json
+++ b/public/levels/world.json
@@ -15,6 +15,11 @@
       "file": "levels/world_tower.json",
       "name": "The Tower",
       "gridPosition": { "x": 1, "y": 1 }
+    },
+    "village": {
+      "file": "levels/world_village.json",
+      "name": "Oakvale Village",
+      "gridPosition": { "x": 0, "y": 1 }
     }
   },
   "transitions": [
@@ -37,6 +42,14 @@
     {
       "from": { "board": "tower", "x": 14, "y": 8, "type": "door" },
       "to":   { "board": "cave", "x": 18, "y": 1 }
+    },
+    {
+      "from": { "board": "clearing", "x": 1, "y": 5, "type": "door" },
+      "to":   { "board": "village", "x": 10, "y": 7 }
+    },
+    {
+      "from": { "board": "village", "x": 10, "y": 7, "type": "door" },
+      "to":   { "board": "clearing", "x": 1, "y": 5 }
     }
   ]
 }

--- a/public/levels/world_clearing.json
+++ b/public/levels/world_clearing.json
@@ -5,8 +5,31 @@
     ["w", ".", ".", ".", ".", "w", ".", "w", "w", "w", ".", ".", ".", "w"],
     ["w", "c", ".", ".", ".", "c", "w", ".", ".", ".", ".", "w", ".", "w"],
     ["w", ".", "m", ".", "m", ".", ".", ".", ".", ".", ".", "w", "c", "w"],
-    ["w", ".", ".", ".", ".", "x", "w", ".", ".", ".", ".", ".", "d", "w"],
+    ["w", "d", ".", ".", ".", "x", "w", ".", ".", ".", ".", ".", "d", "w"],
     ["w", "w", "w", "w", "w", "w", "w", "w", "w", "w", "w", "w", "w", "w"]
   ],
-  "required_crystals": 3
+  "required_crystals": 3,
+  "entities": [
+    {
+      "id": "clearing_sign",
+      "type": "interactive",
+      "x": 7,
+      "y": 3,
+      "properties": {
+        "objectType": "sign",
+        "text": "The Clearing. Exits lead to the cave and tower. A path south leads to the village."
+      }
+    },
+    {
+      "id": "clearing_potion",
+      "type": "item",
+      "x": 10,
+      "y": 4,
+      "glyph": "🧪",
+      "properties": {
+        "itemId": "health_potion",
+        "description": "A health potion found in the clearing."
+      }
+    }
+  ]
 }

--- a/public/levels/world_village.json
+++ b/public/levels/world_village.json
@@ -1,0 +1,76 @@
+{
+  "tiles": [
+    ["w", "w", "w", "w", "w", "w", "w", "w", "w", "w", "w", "w"],
+    ["w", "p", ".", ".", ".", ".", ".", ".", ".", ".", ".", "w"],
+    ["w", ".", ".", ".", ".", ".", ".", ".", ".", ".", ".", "w"],
+    ["w", ".", ".", ".", ".", ".", ".", ".", ".", ".", ".", "w"],
+    ["w", ".", ".", ".", ".", ".", ".", ".", ".", ".", ".", "w"],
+    ["w", ".", ".", ".", ".", ".", ".", ".", ".", ".", ".", "w"],
+    ["w", ".", ".", ".", ".", ".", ".", ".", ".", ".", ".", "w"],
+    ["w", ".", ".", ".", ".", ".", ".", ".", ".", ".", "d", "w"],
+    ["w", "w", "w", "w", "w", "w", "w", "w", "w", "w", "w", "w"]
+  ],
+  "required_crystals": 0,
+  "entities": [
+    {
+      "id": "elder",
+      "type": "npc",
+      "x": 3,
+      "y": 2,
+      "glyph": "👴",
+      "properties": {
+        "name": "Village Elder",
+        "dialogue": [
+          "Welcome to the village, traveler.",
+          "The crystal cave to the east holds many secrets.",
+          "Be careful of the slimes — they bite!"
+        ]
+      }
+    },
+    {
+      "id": "slime1",
+      "type": "enemy",
+      "x": 8,
+      "y": 5,
+      "glyph": "🟢",
+      "properties": {
+        "health": 2,
+        "damage": 1
+      }
+    },
+    {
+      "id": "health_potion",
+      "type": "item",
+      "x": 5,
+      "y": 6,
+      "glyph": "🧪",
+      "properties": {
+        "itemId": "health_potion",
+        "description": "A health potion. Restores vitality!"
+      }
+    },
+    {
+      "id": "village_sign",
+      "type": "interactive",
+      "x": 2,
+      "y": 1,
+      "properties": {
+        "objectType": "sign",
+        "text": "Welcome to Oakvale Village. Press SPACE to interact with things!"
+      }
+    },
+    {
+      "id": "treasure_chest",
+      "type": "interactive",
+      "x": 9,
+      "y": 3,
+      "glyph": "📦",
+      "properties": {
+        "objectType": "chest",
+        "itemId": "gold_key",
+        "description": "Found a golden key!",
+        "openedGlyph": "📭"
+      }
+    }
+  ]
+}

--- a/src/core/Board.js
+++ b/src/core/Board.js
@@ -8,6 +8,7 @@ export class Board {
         this.width = this.tiles[0].length;
         this.height = this.tiles.length;
         this.requiredCrystals = data.required_crystals || 0;
+        this.originalEntities = data.entities || null;
         this.startX = 0;
         this.startY = 0;
         this.findStartPosition();
@@ -48,10 +49,14 @@ export class Board {
     }
 
     getOriginalState() {
-        return {
+        const state = {
             tiles: this.originalTiles,
             required_crystals: this.requiredCrystals
         };
+        if (this.originalEntities) {
+            state.entities = this.originalEntities;
+        }
+        return state;
     }
 
     getTile(x, y) {

--- a/src/entities/DialogueSystem.js
+++ b/src/entities/DialogueSystem.js
@@ -1,0 +1,152 @@
+import { showDialogue, hideDialogue } from '../ui/messages.js';
+
+/**
+ * Manages dialogue display and input routing.
+ * When active, game input routes here instead of player movement.
+ *
+ * Dialogue format:
+ *   { speaker: string, nodes: [{ text: string, choices?: [{ text: string, next: number }] }] }
+ *
+ * Simple dialogue (single text):
+ *   startSimple(speaker, text)
+ */
+export class DialogueSystem {
+    constructor() {
+        this.active = false;
+        this.currentDialogue = null;
+        this.currentNodeIndex = 0;
+        this.selectedChoice = 0;
+        this.onComplete = null;
+    }
+
+    /**
+     * Start a full dialogue sequence.
+     * @param {Object} dialogue - { speaker, nodes: [{ text, choices? }] }
+     * @param {function} [onComplete] - Called when dialogue ends
+     */
+    start(dialogue, onComplete) {
+        this.active = true;
+        this.currentDialogue = dialogue;
+        this.currentNodeIndex = 0;
+        this.selectedChoice = 0;
+        this.onComplete = onComplete || null;
+        this._render();
+    }
+
+    /**
+     * Convenience for a single-line dialogue.
+     * @param {string} speaker
+     * @param {string} text
+     * @param {function} [onComplete]
+     */
+    startSimple(speaker, text, onComplete) {
+        this.start({
+            speaker,
+            nodes: [{ text }]
+        }, onComplete);
+    }
+
+    /**
+     * Get the current dialogue node.
+     * @returns {Object|null} { text, choices? }
+     */
+    getCurrentNode() {
+        if (!this.active || !this.currentDialogue) return null;
+        return this.currentDialogue.nodes[this.currentNodeIndex] || null;
+    }
+
+    /**
+     * Advance to the next node or select a choice.
+     * @returns {boolean} True if dialogue is still active after advancing
+     */
+    advance() {
+        if (!this.active) return false;
+
+        const node = this.getCurrentNode();
+        if (!node) {
+            this.close();
+            return false;
+        }
+
+        // If node has choices and a choice is selected, go to that node
+        if (node.choices && node.choices.length > 0) {
+            const choice = node.choices[this.selectedChoice];
+            if (choice && choice.next !== undefined) {
+                this.currentNodeIndex = choice.next;
+                this.selectedChoice = 0;
+                if (this.currentNodeIndex < this.currentDialogue.nodes.length) {
+                    this._render();
+                    return true;
+                }
+            }
+            this.close();
+            return false;
+        }
+
+        // No choices: advance to next node sequentially
+        this.currentNodeIndex++;
+        this.selectedChoice = 0;
+        if (this.currentNodeIndex < this.currentDialogue.nodes.length) {
+            this._render();
+            return true;
+        }
+
+        this.close();
+        return false;
+    }
+
+    /**
+     * Move choice selection up.
+     */
+    selectPrevious() {
+        const node = this.getCurrentNode();
+        if (node && node.choices && node.choices.length > 0) {
+            this.selectedChoice = Math.max(0, this.selectedChoice - 1);
+            this._render();
+        }
+    }
+
+    /**
+     * Move choice selection down.
+     */
+    selectNext() {
+        const node = this.getCurrentNode();
+        if (node && node.choices && node.choices.length > 0) {
+            this.selectedChoice = Math.min(node.choices.length - 1, this.selectedChoice + 1);
+            this._render();
+        }
+    }
+
+    /**
+     * Close the dialogue immediately.
+     */
+    close() {
+        this.active = false;
+        hideDialogue();
+        const cb = this.onComplete;
+        this.currentDialogue = null;
+        this.currentNodeIndex = 0;
+        this.selectedChoice = 0;
+        this.onComplete = null;
+        if (cb) cb();
+    }
+
+    /**
+     * Render the current dialogue state to the UI.
+     */
+    _render() {
+        const node = this.getCurrentNode();
+        if (!node) return;
+
+        const choices = node.choices
+            ? node.choices.map(c => c.text)
+            : null;
+
+        showDialogue(
+            this.currentDialogue.speaker,
+            node.text,
+            choices,
+            this.selectedChoice
+        );
+    }
+}

--- a/src/entities/Enemy.js
+++ b/src/entities/Enemy.js
@@ -1,0 +1,93 @@
+import { Entity } from './Entity.js';
+
+/**
+ * Enemy entity with greedy chase AI and combat.
+ * Moves one step toward the player each turn (Manhattan distance).
+ */
+export class Enemy extends Entity {
+    /**
+     * @param {Object} config
+     * @param {number} [config.properties.health=1] - Hit points
+     * @param {number} [config.properties.damage=1] - Damage dealt to player on contact
+     */
+    constructor(config) {
+        super({ ...config, type: 'enemy', blocking: true });
+        this.health = this.properties.health || 1;
+        this.damage = this.properties.damage || 1;
+    }
+
+    /**
+     * Player attacks this enemy. Decrements health, deactivates if defeated.
+     * @param {Object} player
+     * @param {Object} context
+     * @returns {{ type: 'combat', defeated: boolean, damageToPlayer: number, enemyId: string }}
+     */
+    interact(player, context) {
+        this.health--;
+        const defeated = this.health <= 0;
+        if (defeated) {
+            this.deactivate();
+        }
+        return {
+            type: 'combat',
+            defeated,
+            damageToPlayer: 0,
+            enemyId: this.id
+        };
+    }
+
+    /**
+     * Greedy chase: pick the adjacent walkable tile closest to player.
+     * Skips tiles occupied by other entities or non-walkable tiles.
+     * @param {Object} player
+     * @param {Object} context
+     * @param {Object} context.board
+     * @param {import('./EntityRegistry.js').EntityRegistry} context.entityRegistry
+     */
+    update(player, context) {
+        if (!context.board || !context.entityRegistry) return;
+
+        const directions = [
+            { dx: 0, dy: -1 },
+            { dx: 0, dy: 1 },
+            { dx: -1, dy: 0 },
+            { dx: 1, dy: 0 }
+        ];
+
+        let bestDir = null;
+        let bestDist = Infinity;
+
+        for (const { dx, dy } of directions) {
+            const nx = this.x + dx;
+            const ny = this.y + dy;
+
+            // Check tile is walkable
+            const tile = context.board.getTile(nx, ny);
+            if (!tile || tile === 'w' || tile === 'm' || tile === 'h') continue;
+
+            // Allow moving onto player's tile (collision)
+            if (nx === player.x && ny === player.y) {
+                const dist = 0;
+                if (dist < bestDist) {
+                    bestDist = dist;
+                    bestDir = { dx, dy };
+                }
+                continue;
+            }
+
+            // Skip tiles occupied by other entities
+            const occupant = context.entityRegistry.getAt(nx, ny);
+            if (occupant && occupant.id !== this.id) continue;
+
+            const dist = Math.abs(nx - player.x) + Math.abs(ny - player.y);
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestDir = { dx, dy };
+            }
+        }
+
+        if (bestDir) {
+            context.entityRegistry.moveEntity(this.id, this.x + bestDir.dx, this.y + bestDir.dy);
+        }
+    }
+}

--- a/src/entities/Entity.js
+++ b/src/entities/Entity.js
@@ -1,0 +1,54 @@
+/**
+ * Base class for all entities that exist on the board as an overlay on tiles.
+ * Entities have position, visual representation, and behavior.
+ */
+export class Entity {
+    /**
+     * @param {Object} config
+     * @param {string} config.id - Unique identifier
+     * @param {string} config.type - Entity type (npc, enemy, item, interactive)
+     * @param {number} config.x - Grid X position
+     * @param {number} config.y - Grid Y position
+     * @param {string} [config.glyph] - Display glyph (emoji)
+     * @param {string} [config.color] - Background color
+     * @param {boolean} [config.blocking=true] - Whether this entity blocks player movement
+     * @param {Object} [config.properties] - Type-specific properties
+     */
+    constructor({ id, type, x, y, glyph = '', color = '', blocking = true, properties = {} }) {
+        this.id = id;
+        this.type = type;
+        this.x = x;
+        this.y = y;
+        this.glyph = glyph;
+        this.color = color;
+        this.blocking = blocking;
+        this.properties = properties;
+        this.active = true;
+    }
+
+    /**
+     * Handle player interaction with this entity.
+     * @param {Object} player - The player object
+     * @param {Object} context - Game context (board, inventory, etc.)
+     * @returns {Object|null} Result describing what happened
+     */
+    interact(player, context) {
+        return null;
+    }
+
+    /**
+     * Called each turn to update entity state.
+     * @param {Object} player - The player object
+     * @param {Object} context - Game context (board, entityRegistry, etc.)
+     */
+    update(player, context) {
+        // Base class does nothing
+    }
+
+    /**
+     * Mark this entity as inactive (removed/defeated/collected).
+     */
+    deactivate() {
+        this.active = false;
+    }
+}

--- a/src/entities/EntityFactory.js
+++ b/src/entities/EntityFactory.js
@@ -1,0 +1,74 @@
+import { NPC } from './NPC.js';
+import { Enemy } from './Enemy.js';
+import { Item } from './Item.js';
+import { InteractiveObject } from './InteractiveObject.js';
+import { Entity } from './Entity.js';
+
+/** Default glyphs per entity type */
+const defaultGlyphs = {
+    npc: '🧑',
+    enemy: '👾',
+    item: '✨',
+    interactive: '❓'
+};
+
+/** Default glyphs for interactive object subtypes */
+const interactiveGlyphs = {
+    sign: '🪧',
+    chest: '📦',
+    lever: '🔲'
+};
+
+/** Default colors per entity type */
+const defaultColors = {
+    npc: '#4a90d9',
+    enemy: '#d94a4a',
+    item: '#d9d94a',
+    interactive: '#8B4513'
+};
+
+/**
+ * Create an entity from a JSON definition.
+ * @param {Object} def - Entity definition from board JSON
+ * @param {string} def.id
+ * @param {string} def.type - 'npc' | 'enemy' | 'item' | 'interactive'
+ * @param {number} def.x
+ * @param {number} def.y
+ * @param {string} [def.glyph]
+ * @param {string} [def.color]
+ * @param {Object} [def.properties]
+ * @returns {Entity}
+ */
+export function createEntity(def) {
+    const config = {
+        ...def,
+        glyph: def.glyph || getDefaultGlyph(def),
+        color: def.color || defaultColors[def.type] || '',
+        properties: def.properties || {}
+    };
+
+    switch (def.type) {
+        case 'npc':
+            return new NPC(config);
+        case 'enemy':
+            return new Enemy(config);
+        case 'item':
+            return new Item(config);
+        case 'interactive':
+            return new InteractiveObject(config);
+        default:
+            return new Entity(config);
+    }
+}
+
+/**
+ * Get the default glyph for a definition.
+ * @param {Object} def
+ * @returns {string}
+ */
+function getDefaultGlyph(def) {
+    if (def.type === 'interactive' && def.properties && def.properties.objectType) {
+        return interactiveGlyphs[def.properties.objectType] || defaultGlyphs.interactive;
+    }
+    return defaultGlyphs[def.type] || '';
+}

--- a/src/entities/EntityRegistry.js
+++ b/src/entities/EntityRegistry.js
@@ -1,0 +1,140 @@
+/**
+ * Per-board spatial index for entities.
+ * Manages entity lifecycle, spatial lookups, and batch updates.
+ */
+export class EntityRegistry {
+    constructor() {
+        /** @type {Map<string, import('./Entity.js').Entity>} */
+        this.entities = new Map();
+        /** @type {Map<string, import('./Entity.js').Entity>} */
+        this.positionIndex = new Map();
+    }
+
+    /**
+     * Generate a position key for spatial indexing.
+     * @param {number} x
+     * @param {number} y
+     * @returns {string}
+     */
+    static posKey(x, y) {
+        return `${x}:${y}`;
+    }
+
+    /**
+     * Add an entity to the registry.
+     * @param {import('./Entity.js').Entity} entity
+     */
+    add(entity) {
+        this.entities.set(entity.id, entity);
+        if (entity.active) {
+            this.positionIndex.set(EntityRegistry.posKey(entity.x, entity.y), entity);
+        }
+    }
+
+    /**
+     * Remove an entity by ID.
+     * @param {string} id
+     */
+    remove(id) {
+        const entity = this.entities.get(id);
+        if (entity) {
+            const key = EntityRegistry.posKey(entity.x, entity.y);
+            if (this.positionIndex.get(key) === entity) {
+                this.positionIndex.delete(key);
+            }
+            this.entities.delete(id);
+        }
+    }
+
+    /**
+     * Get the active entity at a grid position.
+     * @param {number} x
+     * @param {number} y
+     * @returns {import('./Entity.js').Entity|null}
+     */
+    getAt(x, y) {
+        const entity = this.positionIndex.get(EntityRegistry.posKey(x, y));
+        return (entity && entity.active) ? entity : null;
+    }
+
+    /**
+     * Move an entity to a new position, updating the spatial index.
+     * @param {string} id
+     * @param {number} newX
+     * @param {number} newY
+     */
+    moveEntity(id, newX, newY) {
+        const entity = this.entities.get(id);
+        if (!entity || !entity.active) return;
+
+        const oldKey = EntityRegistry.posKey(entity.x, entity.y);
+        if (this.positionIndex.get(oldKey) === entity) {
+            this.positionIndex.delete(oldKey);
+        }
+
+        entity.x = newX;
+        entity.y = newY;
+        this.positionIndex.set(EntityRegistry.posKey(newX, newY), entity);
+    }
+
+    /**
+     * Get all active entities.
+     * @returns {import('./Entity.js').Entity[]}
+     */
+    getAll() {
+        return Array.from(this.entities.values()).filter(e => e.active);
+    }
+
+    /**
+     * Get all active entities of a specific type.
+     * @param {string} type
+     * @returns {import('./Entity.js').Entity[]}
+     */
+    getAllOfType(type) {
+        return this.getAll().filter(e => e.type === type);
+    }
+
+    /**
+     * Call update() on each active entity.
+     * @param {Object} player
+     * @param {Object} context
+     */
+    updateAll(player, context) {
+        for (const entity of this.entities.values()) {
+            if (entity.active) {
+                entity.update(player, context);
+            }
+        }
+    }
+
+    /**
+     * Remove inactive entities from both maps.
+     */
+    cleanup() {
+        for (const [id, entity] of this.entities) {
+            if (!entity.active) {
+                const key = EntityRegistry.posKey(entity.x, entity.y);
+                if (this.positionIndex.get(key) === entity) {
+                    this.positionIndex.delete(key);
+                }
+                this.entities.delete(id);
+            }
+        }
+    }
+
+    /**
+     * Build a registry from an array of entity definitions.
+     * @param {Object[]} defs - Entity definitions from board JSON
+     * @param {function(Object): import('./Entity.js').Entity} factoryFn - Creates entity from definition
+     * @returns {EntityRegistry}
+     */
+    static fromDefinitions(defs, factoryFn) {
+        const registry = new EntityRegistry();
+        if (!defs || !Array.isArray(defs)) return registry;
+        for (const def of defs) {
+            const entity = factoryFn(def);
+            registry.add(entity);
+        }
+        return registry;
+    }
+}

--- a/src/entities/InteractiveObject.js
+++ b/src/entities/InteractiveObject.js
@@ -1,0 +1,73 @@
+import { Entity } from './Entity.js';
+
+/**
+ * Interactive objects: signs, chests, levers.
+ * Behavior determined by properties.objectType.
+ */
+export class InteractiveObject extends Entity {
+    /**
+     * @param {Object} config
+     * @param {string} config.properties.objectType - 'sign' | 'chest' | 'lever'
+     * @param {string} [config.properties.text] - Text for signs
+     * @param {string} [config.properties.itemId] - Item in chest
+     * @param {string} [config.properties.description] - Item description for chest
+     */
+    constructor(config) {
+        super({ ...config, type: 'interactive', blocking: true });
+        this.opened = false;
+        this.activated = false;
+    }
+
+    /**
+     * Handle interaction based on object type.
+     * @param {Object} player
+     * @param {Object} context
+     * @returns {Object} Result describing the interaction
+     */
+    interact(player, context) {
+        switch (this.properties.objectType) {
+            case 'sign':
+                return this._interactSign();
+            case 'chest':
+                return this._interactChest();
+            case 'lever':
+                return this._interactLever();
+            default:
+                return null;
+        }
+    }
+
+    _interactSign() {
+        return {
+            type: 'dialogue',
+            speaker: 'Sign',
+            text: this.properties.text || ''
+        };
+    }
+
+    _interactChest() {
+        if (this.opened) {
+            return {
+                type: 'dialogue',
+                speaker: 'Chest',
+                text: 'The chest is empty.'
+            };
+        }
+        this.opened = true;
+        this.glyph = this.properties.openedGlyph || '📭';
+        return {
+            type: 'pickup',
+            itemId: this.properties.itemId || 'unknown',
+            description: this.properties.description || 'Found something in the chest!'
+        };
+    }
+
+    _interactLever() {
+        this.activated = !this.activated;
+        return {
+            type: 'lever',
+            activated: this.activated,
+            leverId: this.id
+        };
+    }
+}

--- a/src/entities/Inventory.js
+++ b/src/entities/Inventory.js
@@ -1,0 +1,86 @@
+/**
+ * Player inventory. Persists across board transitions.
+ * Tracks item counts by item ID.
+ */
+export class Inventory {
+    constructor() {
+        /** @type {Map<string, number>} */
+        this.items = new Map();
+    }
+
+    /**
+     * Add items to inventory.
+     * @param {string} itemId
+     * @param {number} [count=1]
+     */
+    add(itemId, count = 1) {
+        this.items.set(itemId, (this.items.get(itemId) || 0) + count);
+    }
+
+    /**
+     * Remove items from inventory.
+     * @param {string} itemId
+     * @param {number} [count=1]
+     * @returns {boolean} True if removal succeeded (had enough items)
+     */
+    remove(itemId, count = 1) {
+        const current = this.items.get(itemId) || 0;
+        if (current < count) return false;
+        const remaining = current - count;
+        if (remaining === 0) {
+            this.items.delete(itemId);
+        } else {
+            this.items.set(itemId, remaining);
+        }
+        return true;
+    }
+
+    /**
+     * Check if inventory contains at least one of this item.
+     * @param {string} itemId
+     * @returns {boolean}
+     */
+    has(itemId) {
+        return (this.items.get(itemId) || 0) > 0;
+    }
+
+    /**
+     * Get the count of an item.
+     * @param {string} itemId
+     * @returns {number}
+     */
+    count(itemId) {
+        return this.items.get(itemId) || 0;
+    }
+
+    /**
+     * Get all items as an array of { itemId, count }.
+     * @returns {{ itemId: string, count: number }[]}
+     */
+    getAll() {
+        return Array.from(this.items.entries()).map(([itemId, count]) => ({ itemId, count }));
+    }
+
+    /**
+     * Serialize for save games.
+     * @returns {Object}
+     */
+    serialize() {
+        return Object.fromEntries(this.items);
+    }
+
+    /**
+     * Deserialize from save data.
+     * @param {Object} data
+     * @returns {Inventory}
+     */
+    static deserialize(data) {
+        const inv = new Inventory();
+        if (data) {
+            for (const [itemId, count] of Object.entries(data)) {
+                inv.items.set(itemId, count);
+            }
+        }
+        return inv;
+    }
+}

--- a/src/entities/Item.js
+++ b/src/entities/Item.js
@@ -1,0 +1,30 @@
+import { Entity } from './Entity.js';
+
+/**
+ * Pickup item entity. Non-blocking, deactivates on pickup.
+ */
+export class Item extends Entity {
+    /**
+     * @param {Object} config
+     * @param {string} config.properties.itemId - Item catalog ID
+     * @param {string} [config.properties.description] - Display description
+     */
+    constructor(config) {
+        super({ ...config, type: 'item', blocking: false });
+    }
+
+    /**
+     * Player picks up this item. Deactivates the entity.
+     * @param {Object} player
+     * @param {Object} context
+     * @returns {{ type: 'pickup', itemId: string, description: string }}
+     */
+    interact(player, context) {
+        this.deactivate();
+        return {
+            type: 'pickup',
+            itemId: this.properties.itemId || this.id,
+            description: this.properties.description || 'Picked up an item'
+        };
+    }
+}

--- a/src/entities/NPC.js
+++ b/src/entities/NPC.js
@@ -1,0 +1,37 @@
+import { Entity } from './Entity.js';
+
+/**
+ * Non-player character with dialogue.
+ * Cycles through dialogue lines on each interaction.
+ */
+export class NPC extends Entity {
+    /**
+     * @param {Object} config
+     * @param {string[]} config.properties.dialogue - Array of dialogue lines
+     * @param {string} [config.properties.name] - NPC display name
+     */
+    constructor(config) {
+        super({ ...config, type: 'npc', blocking: true });
+        this.dialogueIndex = 0;
+    }
+
+    /**
+     * Returns dialogue result, cycling through dialogue lines.
+     * @param {Object} player
+     * @param {Object} context
+     * @returns {{ type: 'dialogue', speaker: string, text: string }}
+     */
+    interact(player, context) {
+        const dialogue = this.properties.dialogue || [];
+        if (dialogue.length === 0) return null;
+
+        const text = dialogue[this.dialogueIndex];
+        this.dialogueIndex = (this.dialogueIndex + 1) % dialogue.length;
+
+        return {
+            type: 'dialogue',
+            speaker: this.properties.name || this.id,
+            text
+        };
+    }
+}

--- a/src/game/Player.js
+++ b/src/game/Player.js
@@ -6,9 +6,21 @@ export class Player {
         this.y = y;
         this.board = board;
         this.crystals = 0;
+        this.facing = { dx: 0, dy: 1 }; // default: facing down
+        this.health = 3;
+    }
+
+    /**
+     * Get the tile position the player is facing.
+     * @returns {{ x: number, y: number }}
+     */
+    getFacingTile() {
+        return { x: this.x + this.facing.dx, y: this.y + this.facing.dy };
     }
 
     move(dx, dy, callbacks) {
+        // Update facing direction on every move attempt
+        this.facing = { dx, dy };
         const newX = this.x + dx;
         const newY = this.y + dy;
         if (newX >= 0 && newX < this.board.width && newY >= 0 && newY < this.board.height) {

--- a/src/game/Player.js
+++ b/src/game/Player.js
@@ -7,6 +7,7 @@ export class Player {
         this.board = board;
         this.crystals = 0;
         this.facing = { dx: 0, dy: 1 }; // default: facing down
+        this.maxHealth = 3;
         this.health = 3;
     }
 

--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -28,3 +28,10 @@ export const glyphs = {
     rightArrow: '→',
     doorGlyph: '🚪',
 };
+
+export const entityColors = {
+    npc: '#4a90d9',
+    enemy: '#d94a4a',
+    item: '#d9d94a',
+    interactive: '#8B4513'
+};

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -319,16 +319,20 @@ document.addEventListener('keydown', (event) => {
     if (dialogueSystem.active) {
         switch (event.key) {
             case 'ArrowUp':
+                event.preventDefault();
                 dialogueSystem.selectPrevious();
                 break;
             case 'ArrowDown':
+                event.preventDefault();
                 dialogueSystem.selectNext();
                 break;
             case 'Enter':
             case ' ':
+                event.preventDefault();
                 dialogueSystem.advance();
                 break;
             case 'Escape':
+                event.preventDefault();
                 dialogueSystem.close();
                 break;
         }

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -46,6 +46,10 @@ function updateViewport() {
 
 function updateGameInfo() {
     document.getElementById('crystal-count').textContent = player.crystals;
+    const healthEl = document.getElementById('health-display');
+    if (healthEl) {
+        healthEl.textContent = `Health: ${player.health}/${player.maxHealth}`;
+    }
 }
 
 /**

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -11,6 +11,7 @@ import { EntityRegistry } from '../entities/EntityRegistry.js';
 import { createEntity } from '../entities/EntityFactory.js';
 import { Inventory } from '../entities/Inventory.js';
 import { DialogueSystem } from '../entities/DialogueSystem.js';
+import { drawHud } from '../ui/HudRenderer.js';
 
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
@@ -62,6 +63,7 @@ function gameLoop() {
     if (board && player) {
         updateViewport();
         drawGame(ctx, board, player, viewportX, viewportY, entityRegistry);
+        drawHud(ctx, player, inventory);
         if (worldGraph && playerState) {
             drawMinimap(ctx, worldGraph, playerState);
         }

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -7,6 +7,10 @@ import { loadBoardFromFile, saveBoardToFile } from '../ui/fileIO.js';
 import { WorldGraph } from '../world/WorldGraph.js';
 import { PlayerState } from '../world/PlayerState.js';
 import { drawMinimap } from '../world/WorldRenderer.js';
+import { EntityRegistry } from '../entities/EntityRegistry.js';
+import { createEntity } from '../entities/EntityFactory.js';
+import { Inventory } from '../entities/Inventory.js';
+import { DialogueSystem } from '../entities/DialogueSystem.js';
 
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
@@ -22,6 +26,11 @@ let gameLoopRunning = false;
 let worldGraph = null;
 let playerState = null;
 let transitioning = false;
+
+// Entity system state
+let entityRegistry = new EntityRegistry();
+let inventory = new Inventory();
+let dialogueSystem = new DialogueSystem();
 
 const playerCallbacks = {
     onGameInfoUpdate: updateGameInfo,
@@ -52,7 +61,7 @@ function updateBoardName(name) {
 function gameLoop() {
     if (board && player) {
         updateViewport();
-        drawGame(ctx, board, player, viewportX, viewportY);
+        drawGame(ctx, board, player, viewportX, viewportY, entityRegistry);
         if (worldGraph && playerState) {
             drawMinimap(ctx, worldGraph, playerState);
         }
@@ -101,8 +110,23 @@ function initGame(boardData) {
     board = new Board(boardData);
     player = new Player(board.startX, board.startY, board);
 
+    // Load entities from board data (backward-compatible: entities key is optional)
+    entityRegistry = loadEntities(boardData);
+
     updateGameInfo();
     startGameLoop();
+}
+
+/**
+ * Load entities from board data into a new EntityRegistry.
+ * @param {Object} boardData
+ * @returns {EntityRegistry}
+ */
+function loadEntities(boardData) {
+    if (boardData.entities && Array.isArray(boardData.entities)) {
+        return EntityRegistry.fromDefinitions(boardData.entities, createEntity);
+    }
+    return new EntityRegistry();
 }
 
 /**
@@ -140,7 +164,11 @@ async function enterBoard(boardId, destX, destY) {
         const startY = destY !== undefined ? destY : board.startY;
 
         player = new Player(startX, startY, board);
+        player.health = 3; // Reset health on board entry
         playerState.enterBoard(boardId);
+
+        // Load entities from board data
+        entityRegistry = loadEntities(boardData);
 
         const info = worldGraph.getBoardInfo(boardId);
         updateBoardName(info ? info.name : boardId);
@@ -173,6 +201,9 @@ function handleTransition(tileX, tileY) {
  * Falls back to legacy sequential levels if world.json is not found.
  */
 async function startGame() {
+    inventory = new Inventory();
+    dialogueSystem = new DialogueSystem();
+
     try {
         const response = await fetch('levels/world.json');
 
@@ -202,6 +233,60 @@ async function startGame() {
     }
 }
 
+/**
+ * Handle player interaction with the entity they are facing.
+ */
+function handleInteraction() {
+    const facing = player.getFacingTile();
+    const entity = entityRegistry.getAt(facing.x, facing.y);
+    if (!entity) return;
+
+    const result = entity.interact(player, { board, entityRegistry, inventory });
+    if (!result) return;
+
+    switch (result.type) {
+        case 'dialogue':
+            dialogueSystem.startSimple(result.speaker, result.text);
+            break;
+        case 'pickup':
+            inventory.add(result.itemId);
+            entityRegistry.cleanup();
+            showMessage(result.description);
+            break;
+        case 'combat': {
+            if (result.defeated) {
+                entityRegistry.cleanup();
+                showMessage(`Defeated the enemy!`);
+            } else {
+                showMessage(`You attack! Enemy has ${entity.health} HP left.`);
+            }
+            break;
+        }
+        case 'lever':
+            showMessage(`Lever ${result.activated ? 'activated' : 'deactivated'}.`);
+            break;
+    }
+}
+
+/**
+ * Check if any enemy is on the player's tile after entity updates.
+ * If so, player takes damage.
+ */
+function checkEnemyCollisions() {
+    const enemies = entityRegistry.getAllOfType('enemy');
+    for (const enemy of enemies) {
+        if (enemy.x === player.x && enemy.y === player.y) {
+            player.health -= enemy.damage;
+            showMessage(`Hit by ${enemy.id}! Health: ${player.health}`);
+            if (player.health <= 0) {
+                showMessage('You have been defeated!');
+                resetGame();
+                return;
+            }
+        }
+    }
+}
+
 function handleFileSelect(event) {
     const file = event.target.files[0];
     if (file) {
@@ -224,8 +309,35 @@ function handleFileSelect(event) {
 document.addEventListener('keydown', (event) => {
     if (transitioning) return;
 
-    if (event.key == 'Enter') {
+    // Route input to dialogue system when active
+    if (dialogueSystem.active) {
+        switch (event.key) {
+            case 'ArrowUp':
+                dialogueSystem.selectPrevious();
+                break;
+            case 'ArrowDown':
+                dialogueSystem.selectNext();
+                break;
+            case 'Enter':
+            case ' ':
+                dialogueSystem.advance();
+                break;
+            case 'Escape':
+                dialogueSystem.close();
+                break;
+        }
+        return;
+    }
+
+    if (event.key === 'Enter') {
         hideMessage();
+        return;
+    }
+
+    // Space = interact with facing entity
+    if (event.key === ' ') {
+        event.preventDefault();
+        handleInteraction();
         return;
     }
 
@@ -238,7 +350,25 @@ document.addEventListener('keydown', (event) => {
 
     const [dx, dy] = moveMap[event.key] || [0, 0];
     if (dx !== 0 || dy !== 0) {
+        // Check if target tile has a blocking entity — skip move if so
+        const targetX = player.x + dx;
+        const targetY = player.y + dy;
+        const blockingEntity = entityRegistry.getAt(targetX, targetY);
+        if (blockingEntity && blockingEntity.blocking) {
+            // Still update facing direction even if blocked by entity
+            player.facing = { dx, dy };
+            return;
+        }
+
         player.move(dx, dy, playerCallbacks);
+
+        // After player moves, update all entities (turn-based: enemies move after player)
+        entityRegistry.updateAll(player, { board, entityRegistry, inventory });
+        entityRegistry.cleanup();
+
+        // Check if an enemy moved onto the player
+        checkEnemyCollisions();
+
         updateViewport();
     }
 });

--- a/src/ui/HudRenderer.js
+++ b/src/ui/HudRenderer.js
@@ -1,0 +1,123 @@
+/**
+ * Canvas-based HUD overlay for health and inventory display.
+ * Follows the minimap pattern: semi-transparent backgrounds drawn on the canvas.
+ */
+
+const PADDING = 10;
+const HUD_BG = 'rgba(0, 0, 0, 0.5)';
+const HEART_FULL = '❤️';
+const HEART_EMPTY = '🖤';
+const HEART_SIZE = 20;
+const HEART_GAP = 4;
+const ITEM_FONT_SIZE = 18;
+const ITEM_GAP = 12;
+
+/** @type {Object<string, string>} */
+export const itemGlyphs = {
+    health_potion: '🧪',
+    gold_key: '🗝️',
+    sword: '⚔️',
+    shield: '🛡️',
+    bow: '🏹',
+    coin: '🪙',
+    gem: '💎',
+    scroll: '📜',
+    ring: '💍',
+    lantern: '🔦'
+};
+
+const FALLBACK_GLYPH = '📦';
+
+/**
+ * Get the display glyph for an item ID.
+ * @param {string} itemId
+ * @returns {string}
+ */
+function getItemGlyph(itemId) {
+    return itemGlyphs[itemId] || FALLBACK_GLYPH;
+}
+
+/**
+ * Draw health display in the top-left corner.
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {number} health - Current health
+ * @param {number} maxHealth - Maximum health
+ */
+export function drawHealth(ctx, health, maxHealth) {
+    const heartCount = maxHealth;
+    const totalWidth = heartCount * HEART_SIZE + (heartCount - 1) * HEART_GAP + PADDING * 2;
+    const totalHeight = HEART_SIZE + PADDING * 2;
+
+    // Background
+    ctx.fillStyle = HUD_BG;
+    ctx.fillRect(PADDING, PADDING, totalWidth, totalHeight);
+
+    // Hearts
+    ctx.font = `${HEART_SIZE}px Arial`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    for (let i = 0; i < heartCount; i++) {
+        const glyph = i < health ? HEART_FULL : HEART_EMPTY;
+        const x = PADDING + PADDING + i * (HEART_SIZE + HEART_GAP) + HEART_SIZE / 2;
+        const y = PADDING + PADDING + HEART_SIZE / 2;
+        ctx.fillText(glyph, x, y);
+    }
+}
+
+/**
+ * Draw inventory display in the bottom-left corner.
+ * Only renders when inventory is non-empty.
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {import('../entities/Inventory.js').Inventory} inventory
+ */
+export function drawInventory(ctx, inventory) {
+    const items = inventory.getAll();
+    if (items.length === 0) return;
+
+    ctx.font = `${ITEM_FONT_SIZE}px Arial`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+
+    // Measure each item entry to calculate total width
+    const entries = items.map(({ itemId, count }) => {
+        const glyph = getItemGlyph(itemId);
+        const label = `${glyph}×${count}`;
+        const width = ctx.measureText(label).width;
+        return { label, width };
+    });
+
+    const totalWidth = entries.reduce((sum, e) => sum + e.width, 0)
+        + (entries.length - 1) * ITEM_GAP
+        + PADDING * 2;
+    const totalHeight = ITEM_FONT_SIZE + PADDING * 2;
+
+    const x = PADDING;
+    const y = ctx.canvas.height - totalHeight - PADDING;
+
+    // Background
+    ctx.fillStyle = HUD_BG;
+    ctx.fillRect(x, y, totalWidth, totalHeight);
+
+    // Items
+    ctx.fillStyle = 'white';
+    let cursorX = x + PADDING;
+    const textY = y + PADDING + ITEM_FONT_SIZE / 2;
+
+    for (let i = 0; i < entries.length; i++) {
+        ctx.fillText(entries[i].label, cursorX, textY);
+        cursorX += entries[i].width + ITEM_GAP;
+    }
+}
+
+/**
+ * Draw the full HUD overlay (health + inventory).
+ * Call after all other rendering in the game loop.
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {import('../game/Player.js').Player} player
+ * @param {import('../entities/Inventory.js').Inventory} inventory
+ */
+export function drawHud(ctx, player, inventory) {
+    drawHealth(ctx, player.health, player.maxHealth);
+    drawInventory(ctx, inventory);
+}

--- a/src/ui/messages.js
+++ b/src/ui/messages.js
@@ -1,3 +1,5 @@
+let activeCountdownInterval = null;
+
 export function showMessage(message, duration = 2000) {
     const messagePanel = document.getElementById('messagePanel');
     const messageText = document.getElementById('messageText');
@@ -16,19 +18,28 @@ export function showMessage(message, duration = 2000) {
         countdownElement.textContent = `${remainingTime}s`;
         if (remainingTime <= 0) {
             clearInterval(countdownInterval);
+            activeCountdownInterval = null;
             hideMessage();
         }
     }, 1000);
+
+    activeCountdownInterval = countdownInterval;
 
     // Hide the message when the OK button is clicked
     const dismissButton = document.getElementById('dismissButton');
     dismissButton.onclick = () => {
         clearInterval(countdownInterval);
+        activeCountdownInterval = null;
         hideMessage();
     };
 }
 
 export function hideMessage() {
+    if (activeCountdownInterval) {
+        clearInterval(activeCountdownInterval);
+        activeCountdownInterval = null;
+    }
+
     const messagePanel = document.getElementById('messagePanel');
     messagePanel.style.display = 'none';
 
@@ -47,22 +58,42 @@ export function hideMessage() {
  * @param {number} [selectedIndex=0] - Currently selected choice index
  */
 export function showDialogue(speaker, text, choices, selectedIndex = 0) {
+    // Cancel any active countdown timer from a prior showMessage()
+    if (activeCountdownInterval) {
+        clearInterval(activeCountdownInterval);
+        activeCountdownInterval = null;
+    }
+    const countdownElement = document.getElementById('countdown');
+    if (countdownElement) {
+        countdownElement.remove();
+    }
+
     const messagePanel = document.getElementById('messagePanel');
     const messageText = document.getElementById('messageText');
 
-    let html = `<strong>${speaker}:</strong> ${text}`;
+    // Build DOM nodes instead of innerHTML to prevent XSS
+    const fragment = document.createDocumentFragment();
+
+    const strong = document.createElement('strong');
+    strong.textContent = speaker + ':';
+    fragment.appendChild(strong);
+    fragment.appendChild(document.createTextNode(' ' + text));
 
     if (choices && choices.length > 0) {
-        html += '<div class="dialogue-choices">';
+        const choicesDiv = document.createElement('div');
+        choicesDiv.className = 'dialogue-choices';
         for (let i = 0; i < choices.length; i++) {
+            const choiceDiv = document.createElement('div');
             const marker = i === selectedIndex ? '▸ ' : '  ';
-            const cls = i === selectedIndex ? 'dialogue-choice selected' : 'dialogue-choice';
-            html += `<div class="${cls}">${marker}${choices[i]}</div>`;
+            choiceDiv.className = i === selectedIndex ? 'dialogue-choice selected' : 'dialogue-choice';
+            choiceDiv.textContent = marker + choices[i];
+            choicesDiv.appendChild(choiceDiv);
         }
-        html += '</div>';
+        fragment.appendChild(choicesDiv);
     }
 
-    messageText.innerHTML = html;
+    messageText.innerHTML = '';
+    messageText.appendChild(fragment);
     messagePanel.style.display = 'flex';
 
     // Hide dismiss button during dialogue (advance with Enter/Space instead)

--- a/src/ui/messages.js
+++ b/src/ui/messages.js
@@ -38,3 +38,56 @@ export function hideMessage() {
         messagePanel.removeChild(countdownElement);
     }
 }
+
+/**
+ * Show a dialogue in the message panel without a countdown timer.
+ * @param {string} speaker - Name of the speaker
+ * @param {string} text - Dialogue text
+ * @param {string[]|null} [choices] - Optional choice labels
+ * @param {number} [selectedIndex=0] - Currently selected choice index
+ */
+export function showDialogue(speaker, text, choices, selectedIndex = 0) {
+    const messagePanel = document.getElementById('messagePanel');
+    const messageText = document.getElementById('messageText');
+
+    let html = `<strong>${speaker}:</strong> ${text}`;
+
+    if (choices && choices.length > 0) {
+        html += '<div class="dialogue-choices">';
+        for (let i = 0; i < choices.length; i++) {
+            const marker = i === selectedIndex ? '▸ ' : '  ';
+            const cls = i === selectedIndex ? 'dialogue-choice selected' : 'dialogue-choice';
+            html += `<div class="${cls}">${marker}${choices[i]}</div>`;
+        }
+        html += '</div>';
+    }
+
+    messageText.innerHTML = html;
+    messagePanel.style.display = 'flex';
+
+    // Hide dismiss button during dialogue (advance with Enter/Space instead)
+    const dismissButton = document.getElementById('dismissButton');
+    if (dismissButton) {
+        dismissButton.style.display = 'none';
+    }
+}
+
+/**
+ * Hide the dialogue panel and restore dismiss button.
+ */
+export function hideDialogue() {
+    const messagePanel = document.getElementById('messagePanel');
+    messagePanel.style.display = 'none';
+
+    // Restore dismiss button
+    const dismissButton = document.getElementById('dismissButton');
+    if (dismissButton) {
+        dismissButton.style.display = '';
+    }
+
+    // Clean up innerHTML
+    const messageText = document.getElementById('messageText');
+    if (messageText) {
+        messageText.innerHTML = '';
+    }
+}

--- a/test/board.test.js
+++ b/test/board.test.js
@@ -124,6 +124,35 @@ describe('Board', () => {
         expect(original.required_crystals).toBe(1);
     });
 
+    test('getOriginalState includes entities when present', () => {
+        const entities = [
+            { type: 'npc', id: 'guard', x: 1, y: 0 }
+        ];
+        const board = new Board({
+            tiles: [
+                ['w', '.', 'w'],
+                ['w', 'p', 'w'],
+                ['w', 'w', 'w']
+            ],
+            required_crystals: 0,
+            entities
+        });
+        const state = board.getOriginalState();
+        expect(state.entities).toEqual(entities);
+    });
+
+    test('getOriginalState omits entities when not present', () => {
+        const board = new Board({
+            tiles: [
+                ['w', '.', 'w'],
+                ['w', 'p', 'w'],
+                ['w', 'w', 'w']
+            ]
+        });
+        const state = board.getOriginalState();
+        expect(state.entities).toBeUndefined();
+    });
+
     test('sampleLevel is exported and valid', () => {
         expect(sampleLevel).toBeDefined();
         expect(sampleLevel.tiles).toBeDefined();

--- a/test/dialogueSystem.test.js
+++ b/test/dialogueSystem.test.js
@@ -1,0 +1,160 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { DialogueSystem } from '../src/entities/DialogueSystem.js';
+
+describe('DialogueSystem', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="messagePanel" style="display: none;">
+                <div id="messageText"></div>
+                <button id="dismissButton"></button>
+            </div>
+        `;
+    });
+
+    test('starts inactive', () => {
+        const ds = new DialogueSystem();
+        expect(ds.active).toBe(false);
+        expect(ds.getCurrentNode()).toBeNull();
+    });
+
+    test('startSimple activates with single node', () => {
+        const ds = new DialogueSystem();
+        ds.startSimple('Bob', 'Hello!');
+        expect(ds.active).toBe(true);
+        expect(ds.getCurrentNode().text).toBe('Hello!');
+    });
+
+    test('advance through single node closes dialogue', () => {
+        const ds = new DialogueSystem();
+        const onComplete = vi.fn();
+        ds.startSimple('Bob', 'Hello!', onComplete);
+
+        const stillActive = ds.advance();
+        expect(stillActive).toBe(false);
+        expect(ds.active).toBe(false);
+        expect(onComplete).toHaveBeenCalled();
+    });
+
+    test('advance through multi-node dialogue', () => {
+        const ds = new DialogueSystem();
+        ds.start({
+            speaker: 'Elder',
+            nodes: [
+                { text: 'First line' },
+                { text: 'Second line' },
+                { text: 'Third line' }
+            ]
+        });
+
+        expect(ds.getCurrentNode().text).toBe('First line');
+
+        expect(ds.advance()).toBe(true);
+        expect(ds.getCurrentNode().text).toBe('Second line');
+
+        expect(ds.advance()).toBe(true);
+        expect(ds.getCurrentNode().text).toBe('Third line');
+
+        expect(ds.advance()).toBe(false);
+        expect(ds.active).toBe(false);
+    });
+
+    test('choice selection and branching', () => {
+        const ds = new DialogueSystem();
+        ds.start({
+            speaker: 'Guard',
+            nodes: [
+                {
+                    text: 'Who goes there?',
+                    choices: [
+                        { text: 'A friend', next: 1 },
+                        { text: 'None of your business', next: 2 }
+                    ]
+                },
+                { text: 'Welcome, friend!' },
+                { text: 'How rude!' }
+            ]
+        });
+
+        expect(ds.selectedChoice).toBe(0);
+
+        // Select second choice
+        ds.selectNext();
+        expect(ds.selectedChoice).toBe(1);
+
+        // Advance with choice selected
+        expect(ds.advance()).toBe(true);
+        expect(ds.getCurrentNode().text).toBe('How rude!');
+
+        expect(ds.advance()).toBe(false);
+    });
+
+    test('selectPrevious clamps to 0', () => {
+        const ds = new DialogueSystem();
+        ds.start({
+            speaker: 'NPC',
+            nodes: [{
+                text: 'Choose:',
+                choices: [
+                    { text: 'A', next: 1 },
+                    { text: 'B', next: 1 }
+                ]
+            }, { text: 'Done' }]
+        });
+
+        ds.selectPrevious();
+        expect(ds.selectedChoice).toBe(0);
+    });
+
+    test('selectNext clamps to last choice', () => {
+        const ds = new DialogueSystem();
+        ds.start({
+            speaker: 'NPC',
+            nodes: [{
+                text: 'Choose:',
+                choices: [
+                    { text: 'A', next: 1 },
+                    { text: 'B', next: 1 }
+                ]
+            }, { text: 'Done' }]
+        });
+
+        ds.selectNext();
+        ds.selectNext();
+        ds.selectNext();
+        expect(ds.selectedChoice).toBe(1);
+    });
+
+    test('close resets state', () => {
+        const ds = new DialogueSystem();
+        const onComplete = vi.fn();
+        ds.start({
+            speaker: 'NPC',
+            nodes: [{ text: 'Hi' }, { text: 'Bye' }]
+        }, onComplete);
+
+        ds.close();
+        expect(ds.active).toBe(false);
+        expect(ds.currentDialogue).toBeNull();
+        expect(onComplete).toHaveBeenCalled();
+    });
+
+    test('showDialogue renders to DOM', () => {
+        const ds = new DialogueSystem();
+        ds.startSimple('Elder', 'Welcome, traveler!');
+
+        const panel = document.getElementById('messagePanel');
+        const text = document.getElementById('messageText');
+        expect(panel.style.display).toBe('flex');
+        expect(text.innerHTML).toContain('Elder');
+        expect(text.innerHTML).toContain('Welcome, traveler!');
+    });
+
+    test('hideDialogue hides panel', () => {
+        const ds = new DialogueSystem();
+        ds.startSimple('Bob', 'Hi');
+        ds.close();
+
+        const panel = document.getElementById('messagePanel');
+        expect(panel.style.display).toBe('none');
+    });
+});

--- a/test/entity.test.js
+++ b/test/entity.test.js
@@ -1,0 +1,47 @@
+import { describe, test, expect } from 'vitest';
+import { Entity } from '../src/entities/Entity.js';
+
+describe('Entity', () => {
+    test('constructs with required properties', () => {
+        const entity = new Entity({ id: 'e1', type: 'npc', x: 3, y: 5 });
+        expect(entity.id).toBe('e1');
+        expect(entity.type).toBe('npc');
+        expect(entity.x).toBe(3);
+        expect(entity.y).toBe(5);
+        expect(entity.active).toBe(true);
+        expect(entity.blocking).toBe(true);
+        expect(entity.glyph).toBe('');
+        expect(entity.color).toBe('');
+        expect(entity.properties).toEqual({});
+    });
+
+    test('constructs with optional properties', () => {
+        const entity = new Entity({
+            id: 'e2', type: 'item', x: 1, y: 2,
+            glyph: '🗝️', color: '#gold', blocking: false,
+            properties: { itemId: 'key' }
+        });
+        expect(entity.glyph).toBe('🗝️');
+        expect(entity.color).toBe('#gold');
+        expect(entity.blocking).toBe(false);
+        expect(entity.properties.itemId).toBe('key');
+    });
+
+    test('interact returns null by default', () => {
+        const entity = new Entity({ id: 'e1', type: 'npc', x: 0, y: 0 });
+        expect(entity.interact({}, {})).toBeNull();
+    });
+
+    test('update does nothing by default', () => {
+        const entity = new Entity({ id: 'e1', type: 'npc', x: 0, y: 0 });
+        // Should not throw
+        entity.update({}, {});
+    });
+
+    test('deactivate sets active to false', () => {
+        const entity = new Entity({ id: 'e1', type: 'npc', x: 0, y: 0 });
+        expect(entity.active).toBe(true);
+        entity.deactivate();
+        expect(entity.active).toBe(false);
+    });
+});

--- a/test/entityIntegration.test.js
+++ b/test/entityIntegration.test.js
@@ -1,0 +1,210 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { Board } from '../src/core/Board.js';
+import { Player } from '../src/game/Player.js';
+import { EntityRegistry } from '../src/entities/EntityRegistry.js';
+import { createEntity } from '../src/entities/EntityFactory.js';
+import { Inventory } from '../src/entities/Inventory.js';
+import { NPC } from '../src/entities/NPC.js';
+import { Enemy } from '../src/entities/Enemy.js';
+import { Item } from '../src/entities/Item.js';
+import { InteractiveObject } from '../src/entities/InteractiveObject.js';
+
+describe('Entity Integration', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="messagePanel" style="display: none;">
+                <div id="messageText"></div>
+                <button id="dismissButton"></button>
+            </div>
+        `;
+    });
+
+    const boardData = {
+        tiles: [
+            ['w', 'w', 'w', 'w', 'w', 'w', 'w'],
+            ['w', 'p', '.', '.', '.', '.', 'w'],
+            ['w', '.', '.', '.', '.', '.', 'w'],
+            ['w', '.', '.', '.', '.', '.', 'w'],
+            ['w', '.', '.', '.', '.', '.', 'w'],
+            ['w', 'w', 'w', 'w', 'w', 'w', 'w']
+        ],
+        required_crystals: 0,
+        entities: [
+            {
+                id: 'test_npc',
+                type: 'npc',
+                x: 3, y: 1,
+                properties: { name: 'Bob', dialogue: ['Hello!', 'Goodbye!'] }
+            },
+            {
+                id: 'test_enemy',
+                type: 'enemy',
+                x: 5, y: 4,
+                properties: { health: 2, damage: 1 }
+            },
+            {
+                id: 'test_item',
+                type: 'item',
+                x: 2, y: 3,
+                properties: { itemId: 'gem', description: 'A shiny gem' }
+            },
+            {
+                id: 'test_chest',
+                type: 'interactive',
+                x: 4, y: 2,
+                properties: { objectType: 'chest', itemId: 'key', description: 'A rusty key' }
+            }
+        ]
+    };
+
+    test('entities load from JSON definitions via factory', () => {
+        const registry = EntityRegistry.fromDefinitions(boardData.entities, createEntity);
+        expect(registry.getAll().length).toBe(4);
+        expect(registry.getAt(3, 1)).toBeInstanceOf(NPC);
+        expect(registry.getAt(5, 4)).toBeInstanceOf(Enemy);
+        expect(registry.getAt(2, 3)).toBeInstanceOf(Item);
+        expect(registry.getAt(4, 2)).toBeInstanceOf(InteractiveObject);
+    });
+
+    test('NPC interaction returns dialogue', () => {
+        const registry = EntityRegistry.fromDefinitions(boardData.entities, createEntity);
+        const npc = registry.getAt(3, 1);
+        const result = npc.interact({}, {});
+        expect(result.type).toBe('dialogue');
+        expect(result.speaker).toBe('Bob');
+        expect(result.text).toBe('Hello!');
+    });
+
+    test('enemy chases player each turn', () => {
+        const board = new Board(boardData);
+        const player = new Player(1, 1, board);
+        const registry = EntityRegistry.fromDefinitions(boardData.entities, createEntity);
+
+        const enemy = registry.getAt(5, 4);
+        const startDist = Math.abs(enemy.x - player.x) + Math.abs(enemy.y - player.y);
+
+        enemy.update(player, { board, entityRegistry: registry });
+
+        const endDist = Math.abs(enemy.x - player.x) + Math.abs(enemy.y - player.y);
+        expect(endDist).toBeLessThan(startDist);
+    });
+
+    test('item pickup adds to inventory and deactivates entity', () => {
+        const registry = EntityRegistry.fromDefinitions(boardData.entities, createEntity);
+        const inventory = new Inventory();
+        const item = registry.getAt(2, 3);
+
+        const result = item.interact({}, { inventory });
+        expect(result.type).toBe('pickup');
+        expect(result.itemId).toBe('gem');
+
+        inventory.add(result.itemId);
+        expect(inventory.has('gem')).toBe(true);
+        expect(item.active).toBe(false);
+
+        registry.cleanup();
+        expect(registry.getAt(2, 3)).toBeNull();
+    });
+
+    test('blocking entity prevents player movement', () => {
+        const board = new Board(boardData);
+        const player = new Player(2, 1, board);
+        const registry = EntityRegistry.fromDefinitions(boardData.entities, createEntity);
+
+        // NPC is at (3, 1) and blocking
+        const npc = registry.getAt(3, 1);
+        expect(npc.blocking).toBe(true);
+
+        // Simulate the check from main.js: target has blocking entity
+        const targetX = player.x + 1;
+        const targetY = player.y;
+        const blockingEntity = registry.getAt(targetX, targetY);
+        expect(blockingEntity).toBe(npc);
+
+        // Player should not move (in the game loop, this would prevent player.move())
+        if (blockingEntity && blockingEntity.blocking) {
+            // Don't move
+        } else {
+            player.move(1, 0, {});
+        }
+        expect(player.x).toBe(2); // unchanged
+    });
+
+    test('non-blocking item does not prevent movement', () => {
+        const registry = EntityRegistry.fromDefinitions(boardData.entities, createEntity);
+        const item = registry.getAt(2, 3);
+        expect(item.blocking).toBe(false);
+
+        // Player can walk through items
+        const blockingEntity = registry.getAt(2, 3);
+        const canMove = !blockingEntity || !blockingEntity.blocking;
+        expect(canMove).toBe(true);
+    });
+
+    test('spatial index updates when entity moves', () => {
+        const registry = EntityRegistry.fromDefinitions(boardData.entities, createEntity);
+
+        const enemy = registry.getAt(5, 4);
+        expect(enemy.id).toBe('test_enemy');
+
+        registry.moveEntity('test_enemy', 4, 4);
+        expect(registry.getAt(5, 4)).toBeNull();
+        expect(registry.getAt(4, 4)).toBe(enemy);
+    });
+
+    test('board without entities key loads empty registry', () => {
+        const noEntityData = {
+            tiles: [['w', 'p', 'w']],
+            required_crystals: 0
+        };
+        const registry = EntityRegistry.fromDefinitions(noEntityData.entities, createEntity);
+        expect(registry.getAll().length).toBe(0);
+    });
+
+    test('chest gives item first time, empty message second time', () => {
+        const registry = EntityRegistry.fromDefinitions(boardData.entities, createEntity);
+        const chest = registry.getAt(4, 2);
+
+        const r1 = chest.interact({}, {});
+        expect(r1.type).toBe('pickup');
+        expect(r1.itemId).toBe('key');
+
+        const r2 = chest.interact({}, {});
+        expect(r2.type).toBe('dialogue');
+        expect(r2.text).toBe('The chest is empty.');
+    });
+
+    test('enemy combat: attack reduces health, defeated removes enemy', () => {
+        const registry = EntityRegistry.fromDefinitions(boardData.entities, createEntity);
+        const enemy = registry.getAt(5, 4);
+
+        // First attack
+        const r1 = enemy.interact({}, {});
+        expect(r1.type).toBe('combat');
+        expect(r1.defeated).toBe(false);
+        expect(enemy.health).toBe(1);
+
+        // Second attack defeats
+        const r2 = enemy.interact({}, {});
+        expect(r2.defeated).toBe(true);
+        expect(enemy.active).toBe(false);
+
+        registry.cleanup();
+        expect(registry.getAt(5, 4)).toBeNull();
+    });
+
+    test('inventory persists across simulated board transitions', () => {
+        const inventory = new Inventory();
+
+        // Pick up item on board 1
+        const reg1 = EntityRegistry.fromDefinitions(boardData.entities, createEntity);
+        const item = reg1.getAt(2, 3);
+        const result = item.interact({}, {});
+        inventory.add(result.itemId);
+
+        // "Transition" to board 2 (new registry, same inventory)
+        const reg2 = EntityRegistry.fromDefinitions([], createEntity);
+        expect(reg2.getAll().length).toBe(0);
+        expect(inventory.has('gem')).toBe(true);
+    });
+});

--- a/test/entityRegistry.test.js
+++ b/test/entityRegistry.test.js
@@ -1,0 +1,130 @@
+import { describe, test, expect } from 'vitest';
+import { Entity } from '../src/entities/Entity.js';
+import { EntityRegistry } from '../src/entities/EntityRegistry.js';
+
+describe('EntityRegistry', () => {
+    function makeEntity(id, x, y, opts = {}) {
+        return new Entity({ id, type: opts.type || 'npc', x, y, ...opts });
+    }
+
+    test('add and getAt', () => {
+        const reg = new EntityRegistry();
+        const e = makeEntity('e1', 3, 5);
+        reg.add(e);
+        expect(reg.getAt(3, 5)).toBe(e);
+        expect(reg.getAt(0, 0)).toBeNull();
+    });
+
+    test('remove clears from both maps', () => {
+        const reg = new EntityRegistry();
+        const e = makeEntity('e1', 3, 5);
+        reg.add(e);
+        reg.remove('e1');
+        expect(reg.getAt(3, 5)).toBeNull();
+        expect(reg.entities.size).toBe(0);
+    });
+
+    test('getAt returns null for inactive entity', () => {
+        const reg = new EntityRegistry();
+        const e = makeEntity('e1', 3, 5);
+        reg.add(e);
+        e.deactivate();
+        expect(reg.getAt(3, 5)).toBeNull();
+    });
+
+    test('moveEntity updates spatial index', () => {
+        const reg = new EntityRegistry();
+        const e = makeEntity('e1', 1, 1);
+        reg.add(e);
+        reg.moveEntity('e1', 2, 3);
+        expect(reg.getAt(1, 1)).toBeNull();
+        expect(reg.getAt(2, 3)).toBe(e);
+        expect(e.x).toBe(2);
+        expect(e.y).toBe(3);
+    });
+
+    test('moveEntity ignores inactive entity', () => {
+        const reg = new EntityRegistry();
+        const e = makeEntity('e1', 1, 1);
+        reg.add(e);
+        e.deactivate();
+        reg.moveEntity('e1', 2, 3);
+        expect(e.x).toBe(1); // unchanged
+    });
+
+    test('getAll returns only active entities', () => {
+        const reg = new EntityRegistry();
+        const e1 = makeEntity('e1', 0, 0);
+        const e2 = makeEntity('e2', 1, 1);
+        reg.add(e1);
+        reg.add(e2);
+        e2.deactivate();
+        expect(reg.getAll()).toEqual([e1]);
+    });
+
+    test('getAllOfType filters by type', () => {
+        const reg = new EntityRegistry();
+        const npc = makeEntity('n1', 0, 0, { type: 'npc' });
+        const enemy = makeEntity('e1', 1, 1, { type: 'enemy' });
+        reg.add(npc);
+        reg.add(enemy);
+        expect(reg.getAllOfType('npc')).toEqual([npc]);
+        expect(reg.getAllOfType('enemy')).toEqual([enemy]);
+    });
+
+    test('updateAll calls update on active entities', () => {
+        const reg = new EntityRegistry();
+        let called = false;
+        const e = makeEntity('e1', 0, 0);
+        e.update = () => { called = true; };
+        reg.add(e);
+        reg.updateAll({}, {});
+        expect(called).toBe(true);
+    });
+
+    test('updateAll skips inactive entities', () => {
+        const reg = new EntityRegistry();
+        let called = false;
+        const e = makeEntity('e1', 0, 0);
+        e.update = () => { called = true; };
+        e.deactivate();
+        reg.add(e);
+        reg.updateAll({}, {});
+        expect(called).toBe(false);
+    });
+
+    test('cleanup removes inactive entities', () => {
+        const reg = new EntityRegistry();
+        const e1 = makeEntity('e1', 0, 0);
+        const e2 = makeEntity('e2', 1, 1);
+        reg.add(e1);
+        reg.add(e2);
+        e1.deactivate();
+        reg.cleanup();
+        expect(reg.entities.size).toBe(1);
+        expect(reg.getAt(0, 0)).toBeNull();
+        expect(reg.getAt(1, 1)).toBe(e2);
+    });
+
+    test('fromDefinitions builds registry via factory', () => {
+        const defs = [
+            { id: 'n1', type: 'npc', x: 0, y: 0 },
+            { id: 'n2', type: 'npc', x: 2, y: 3 }
+        ];
+        const factory = (def) => new Entity(def);
+        const reg = EntityRegistry.fromDefinitions(defs, factory);
+        expect(reg.getAll().length).toBe(2);
+        expect(reg.getAt(0, 0).id).toBe('n1');
+        expect(reg.getAt(2, 3).id).toBe('n2');
+    });
+
+    test('fromDefinitions handles null/undefined defs', () => {
+        const reg = EntityRegistry.fromDefinitions(null, () => {});
+        expect(reg.getAll().length).toBe(0);
+    });
+
+    test('fromDefinitions handles empty array', () => {
+        const reg = EntityRegistry.fromDefinitions([], () => {});
+        expect(reg.getAll().length).toBe(0);
+    });
+});

--- a/test/entitySubtypes.test.js
+++ b/test/entitySubtypes.test.js
@@ -1,0 +1,295 @@
+import { describe, test, expect } from 'vitest';
+import { NPC } from '../src/entities/NPC.js';
+import { Enemy } from '../src/entities/Enemy.js';
+import { Item } from '../src/entities/Item.js';
+import { InteractiveObject } from '../src/entities/InteractiveObject.js';
+import { createEntity } from '../src/entities/EntityFactory.js';
+import { EntityRegistry } from '../src/entities/EntityRegistry.js';
+import { Board } from '../src/core/Board.js';
+
+describe('NPC', () => {
+    test('interact returns dialogue and cycles', () => {
+        const npc = new NPC({
+            id: 'elder', type: 'npc', x: 0, y: 0,
+            properties: { name: 'Elder', dialogue: ['Hello!', 'Welcome!', 'Goodbye!'] }
+        });
+
+        const r1 = npc.interact({}, {});
+        expect(r1.type).toBe('dialogue');
+        expect(r1.speaker).toBe('Elder');
+        expect(r1.text).toBe('Hello!');
+
+        const r2 = npc.interact({}, {});
+        expect(r2.text).toBe('Welcome!');
+
+        const r3 = npc.interact({}, {});
+        expect(r3.text).toBe('Goodbye!');
+
+        // Cycles back
+        const r4 = npc.interact({}, {});
+        expect(r4.text).toBe('Hello!');
+    });
+
+    test('interact returns null for empty dialogue', () => {
+        const npc = new NPC({ id: 'n1', type: 'npc', x: 0, y: 0, properties: {} });
+        expect(npc.interact({}, {})).toBeNull();
+    });
+
+    test('uses id as speaker when no name', () => {
+        const npc = new NPC({
+            id: 'guard', type: 'npc', x: 0, y: 0,
+            properties: { dialogue: ['Halt!'] }
+        });
+        expect(npc.interact({}, {}).speaker).toBe('guard');
+    });
+
+    test('is blocking by default', () => {
+        const npc = new NPC({ id: 'n1', type: 'npc', x: 0, y: 0, properties: {} });
+        expect(npc.blocking).toBe(true);
+    });
+});
+
+describe('Enemy', () => {
+    test('interact decrements health and returns combat result', () => {
+        const enemy = new Enemy({
+            id: 'slime', type: 'enemy', x: 5, y: 5,
+            properties: { health: 2 }
+        });
+
+        const r1 = enemy.interact({}, {});
+        expect(r1.type).toBe('combat');
+        expect(r1.defeated).toBe(false);
+        expect(enemy.health).toBe(1);
+        expect(enemy.active).toBe(true);
+
+        const r2 = enemy.interact({}, {});
+        expect(r2.defeated).toBe(true);
+        expect(enemy.health).toBe(0);
+        expect(enemy.active).toBe(false);
+    });
+
+    test('greedy chase moves toward player', () => {
+        const board = new Board({
+            tiles: [
+                ['w', 'w', 'w', 'w', 'w'],
+                ['w', '.', '.', '.', 'w'],
+                ['w', '.', '.', '.', 'w'],
+                ['w', 'w', 'w', 'w', 'w']
+            ],
+            required_crystals: 0
+        });
+
+        const enemy = new Enemy({
+            id: 'e1', type: 'enemy', x: 3, y: 2,
+            properties: { health: 1 }
+        });
+        const registry = new EntityRegistry();
+        registry.add(enemy);
+
+        const player = { x: 1, y: 1 };
+        enemy.update(player, { board, entityRegistry: registry });
+
+        // Enemy should have moved closer to player
+        const dist = Math.abs(enemy.x - player.x) + Math.abs(enemy.y - player.y);
+        expect(dist).toBeLessThan(4); // Was 3, should be 2 or less now
+    });
+
+    test('chase avoids walls', () => {
+        const board = new Board({
+            tiles: [
+                ['w', 'w', 'w', 'w', 'w'],
+                ['w', '.', 'w', '.', 'w'],
+                ['w', '.', '.', '.', 'w'],
+                ['w', 'w', 'w', 'w', 'w']
+            ],
+            required_crystals: 0
+        });
+
+        const enemy = new Enemy({
+            id: 'e1', type: 'enemy', x: 3, y: 1,
+            properties: { health: 1 }
+        });
+        const registry = new EntityRegistry();
+        registry.add(enemy);
+
+        const player = { x: 1, y: 1 };
+        enemy.update(player, { board, entityRegistry: registry });
+
+        // Should not move into wall at (2,1), should move down to (3,2)
+        expect(enemy.x).toBe(3);
+        expect(enemy.y).toBe(2);
+    });
+
+    test('chase skips tiles occupied by other entities', () => {
+        const board = new Board({
+            tiles: [
+                ['w', 'w', 'w', 'w', 'w'],
+                ['w', '.', '.', '.', 'w'],
+                ['w', '.', '.', '.', 'w'],
+                ['w', 'w', 'w', 'w', 'w']
+            ],
+            required_crystals: 0
+        });
+
+        const enemy = new Enemy({
+            id: 'e1', type: 'enemy', x: 3, y: 1,
+            properties: { health: 1 }
+        });
+        const blocker = new Enemy({
+            id: 'e2', type: 'enemy', x: 2, y: 1,
+            properties: { health: 1 }
+        });
+        const registry = new EntityRegistry();
+        registry.add(enemy);
+        registry.add(blocker);
+
+        const player = { x: 1, y: 1 };
+        enemy.update(player, { board, entityRegistry: registry });
+
+        // Can't move left (occupied by e2), should move down
+        expect(enemy.x).toBe(3);
+        expect(enemy.y).toBe(2);
+    });
+
+    test('default health is 1', () => {
+        const enemy = new Enemy({ id: 'e1', type: 'enemy', x: 0, y: 0, properties: {} });
+        expect(enemy.health).toBe(1);
+    });
+});
+
+describe('Item', () => {
+    test('interact returns pickup and deactivates', () => {
+        const item = new Item({
+            id: 'potion', type: 'item', x: 2, y: 3,
+            properties: { itemId: 'health_potion', description: 'Restores health' }
+        });
+
+        expect(item.blocking).toBe(false);
+
+        const result = item.interact({}, {});
+        expect(result.type).toBe('pickup');
+        expect(result.itemId).toBe('health_potion');
+        expect(result.description).toBe('Restores health');
+        expect(item.active).toBe(false);
+    });
+
+    test('uses id as fallback itemId', () => {
+        const item = new Item({ id: 'key1', type: 'item', x: 0, y: 0, properties: {} });
+        const result = item.interact({}, {});
+        expect(result.itemId).toBe('key1');
+    });
+});
+
+describe('InteractiveObject', () => {
+    test('sign returns dialogue', () => {
+        const sign = new InteractiveObject({
+            id: 's1', type: 'interactive', x: 0, y: 0,
+            properties: { objectType: 'sign', text: 'Welcome to the village!' }
+        });
+
+        const result = sign.interact({}, {});
+        expect(result.type).toBe('dialogue');
+        expect(result.speaker).toBe('Sign');
+        expect(result.text).toBe('Welcome to the village!');
+    });
+
+    test('chest gives item on first interact, empty on second', () => {
+        const chest = new InteractiveObject({
+            id: 'c1', type: 'interactive', x: 0, y: 0,
+            properties: { objectType: 'chest', itemId: 'gold_key', description: 'A golden key!' }
+        });
+
+        const r1 = chest.interact({}, {});
+        expect(r1.type).toBe('pickup');
+        expect(r1.itemId).toBe('gold_key');
+        expect(chest.opened).toBe(true);
+
+        const r2 = chest.interact({}, {});
+        expect(r2.type).toBe('dialogue');
+        expect(r2.text).toBe('The chest is empty.');
+    });
+
+    test('lever toggles', () => {
+        const lever = new InteractiveObject({
+            id: 'lev1', type: 'interactive', x: 0, y: 0,
+            properties: { objectType: 'lever' }
+        });
+
+        const r1 = lever.interact({}, {});
+        expect(r1.type).toBe('lever');
+        expect(r1.activated).toBe(true);
+
+        const r2 = lever.interact({}, {});
+        expect(r2.activated).toBe(false);
+    });
+
+    test('unknown objectType returns null', () => {
+        const obj = new InteractiveObject({
+            id: 'x1', type: 'interactive', x: 0, y: 0,
+            properties: { objectType: 'unknown' }
+        });
+        expect(obj.interact({}, {})).toBeNull();
+    });
+});
+
+describe('EntityFactory', () => {
+    test('creates NPC from definition', () => {
+        const entity = createEntity({
+            id: 'n1', type: 'npc', x: 1, y: 2,
+            properties: { name: 'Bob', dialogue: ['Hi'] }
+        });
+        expect(entity).toBeInstanceOf(NPC);
+        expect(entity.glyph).toBe('🧑');
+    });
+
+    test('creates Enemy from definition', () => {
+        const entity = createEntity({
+            id: 'e1', type: 'enemy', x: 3, y: 4,
+            properties: { health: 3 }
+        });
+        expect(entity).toBeInstanceOf(Enemy);
+        expect(entity.health).toBe(3);
+        expect(entity.glyph).toBe('👾');
+    });
+
+    test('creates Item from definition', () => {
+        const entity = createEntity({
+            id: 'i1', type: 'item', x: 0, y: 0,
+            properties: { itemId: 'key' }
+        });
+        expect(entity).toBeInstanceOf(Item);
+        expect(entity.blocking).toBe(false);
+        expect(entity.glyph).toBe('✨');
+    });
+
+    test('creates InteractiveObject from definition', () => {
+        const entity = createEntity({
+            id: 's1', type: 'interactive', x: 0, y: 0,
+            properties: { objectType: 'sign', text: 'Hello' }
+        });
+        expect(entity).toBeInstanceOf(InteractiveObject);
+        expect(entity.glyph).toBe('🪧');
+    });
+
+    test('chest gets chest glyph', () => {
+        const entity = createEntity({
+            id: 'c1', type: 'interactive', x: 0, y: 0,
+            properties: { objectType: 'chest', itemId: 'key' }
+        });
+        expect(entity.glyph).toBe('📦');
+    });
+
+    test('preserves custom glyph', () => {
+        const entity = createEntity({
+            id: 'n1', type: 'npc', x: 0, y: 0,
+            glyph: '👴',
+            properties: { dialogue: ['Hi'] }
+        });
+        expect(entity.glyph).toBe('👴');
+    });
+
+    test('unknown type creates base Entity', () => {
+        const entity = createEntity({ id: 'x1', type: 'unknown', x: 0, y: 0 });
+        expect(entity.type).toBe('unknown');
+    });
+});

--- a/test/hudRenderer.test.js
+++ b/test/hudRenderer.test.js
@@ -1,0 +1,151 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { drawHealth, drawInventory, drawHud, itemGlyphs } from '../src/ui/HudRenderer.js';
+import { Inventory } from '../src/entities/Inventory.js';
+
+/** Create a mock canvas 2D context. */
+function createMockCtx() {
+    return {
+        canvas: { width: 640, height: 480 },
+        fillStyle: '',
+        font: '',
+        textAlign: '',
+        textBaseline: '',
+        fillRect: vi.fn(),
+        fillText: vi.fn(),
+        measureText: vi.fn(() => ({ width: 40 }))
+    };
+}
+
+describe('HudRenderer', () => {
+    let ctx;
+
+    beforeEach(() => {
+        ctx = createMockCtx();
+    });
+
+    describe('drawHealth', () => {
+        test('draws background rect', () => {
+            drawHealth(ctx, 3, 3);
+            expect(ctx.fillRect).toHaveBeenCalled();
+            // First fillRect call is the background
+            const bgCall = ctx.fillRect.mock.calls[0];
+            expect(bgCall[0]).toBe(10); // PADDING
+            expect(bgCall[1]).toBe(10); // PADDING
+        });
+
+        test('draws correct number of hearts', () => {
+            drawHealth(ctx, 2, 3);
+            // 3 hearts total (fillText calls)
+            expect(ctx.fillText).toHaveBeenCalledTimes(3);
+        });
+
+        test('full hearts match current health', () => {
+            drawHealth(ctx, 1, 3);
+            const hearts = ctx.fillText.mock.calls.map(c => c[0]);
+            expect(hearts[0]).toBe('❤️');
+            expect(hearts[1]).toBe('🖤');
+            expect(hearts[2]).toBe('🖤');
+        });
+
+        test('all hearts full at max health', () => {
+            drawHealth(ctx, 3, 3);
+            const hearts = ctx.fillText.mock.calls.map(c => c[0]);
+            expect(hearts.every(h => h === '❤️')).toBe(true);
+        });
+
+        test('all hearts empty at zero health', () => {
+            drawHealth(ctx, 0, 3);
+            const hearts = ctx.fillText.mock.calls.map(c => c[0]);
+            expect(hearts.every(h => h === '🖤')).toBe(true);
+        });
+    });
+
+    describe('drawInventory', () => {
+        test('does not draw when inventory is empty', () => {
+            const inv = new Inventory();
+            drawInventory(ctx, inv);
+            expect(ctx.fillRect).not.toHaveBeenCalled();
+            expect(ctx.fillText).not.toHaveBeenCalled();
+        });
+
+        test('draws background and items when inventory has items', () => {
+            const inv = new Inventory();
+            inv.add('health_potion', 2);
+            drawInventory(ctx, inv);
+            expect(ctx.fillRect).toHaveBeenCalledTimes(1); // background
+            expect(ctx.fillText).toHaveBeenCalledTimes(1); // one item entry
+        });
+
+        test('renders correct glyph and count', () => {
+            const inv = new Inventory();
+            inv.add('health_potion', 3);
+            drawInventory(ctx, inv);
+            const text = ctx.fillText.mock.calls[0][0];
+            expect(text).toBe('🧪×3');
+        });
+
+        test('uses fallback glyph for unknown items', () => {
+            const inv = new Inventory();
+            inv.add('mystery_orb', 1);
+            drawInventory(ctx, inv);
+            const text = ctx.fillText.mock.calls[0][0];
+            expect(text).toBe('📦×1');
+        });
+
+        test('renders multiple items', () => {
+            const inv = new Inventory();
+            inv.add('health_potion', 2);
+            inv.add('gold_key', 1);
+            drawInventory(ctx, inv);
+            expect(ctx.fillText).toHaveBeenCalledTimes(2);
+        });
+
+        test('positions at bottom-left of canvas', () => {
+            const inv = new Inventory();
+            inv.add('health_potion', 1);
+            drawInventory(ctx, inv);
+            // Background rect y should be near bottom
+            const bgCall = ctx.fillRect.mock.calls[0];
+            expect(bgCall[0]).toBe(10); // PADDING from left
+            expect(bgCall[1]).toBeGreaterThan(400); // near bottom of 480px canvas
+        });
+    });
+
+    describe('drawHud', () => {
+        test('draws both health and inventory', () => {
+            const player = { health: 2, maxHealth: 3 };
+            const inv = new Inventory();
+            inv.add('gold_key', 1);
+
+            drawHud(ctx, player, inv);
+
+            // Should have fillRect calls for health bg + inventory bg
+            expect(ctx.fillRect).toHaveBeenCalledTimes(2);
+            // Should have fillText for 3 hearts + 1 item
+            expect(ctx.fillText).toHaveBeenCalledTimes(4);
+        });
+
+        test('draws only health when inventory is empty', () => {
+            const player = { health: 3, maxHealth: 3 };
+            const inv = new Inventory();
+
+            drawHud(ctx, player, inv);
+
+            // Only health background
+            expect(ctx.fillRect).toHaveBeenCalledTimes(1);
+            // 3 hearts only
+            expect(ctx.fillText).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    describe('itemGlyphs', () => {
+        test('has glyphs for common items', () => {
+            expect(itemGlyphs.health_potion).toBe('🧪');
+            expect(itemGlyphs.gold_key).toBe('🗝️');
+        });
+
+        test('is a plain object', () => {
+            expect(typeof itemGlyphs).toBe('object');
+        });
+    });
+});

--- a/test/inventory.test.js
+++ b/test/inventory.test.js
@@ -1,0 +1,73 @@
+import { describe, test, expect } from 'vitest';
+import { Inventory } from '../src/entities/Inventory.js';
+
+describe('Inventory', () => {
+    test('starts empty', () => {
+        const inv = new Inventory();
+        expect(inv.getAll()).toEqual([]);
+        expect(inv.has('key')).toBe(false);
+        expect(inv.count('key')).toBe(0);
+    });
+
+    test('add increases count', () => {
+        const inv = new Inventory();
+        inv.add('key');
+        expect(inv.has('key')).toBe(true);
+        expect(inv.count('key')).toBe(1);
+
+        inv.add('key', 2);
+        expect(inv.count('key')).toBe(3);
+    });
+
+    test('remove decreases count', () => {
+        const inv = new Inventory();
+        inv.add('potion', 3);
+
+        expect(inv.remove('potion', 2)).toBe(true);
+        expect(inv.count('potion')).toBe(1);
+
+        expect(inv.remove('potion')).toBe(true);
+        expect(inv.has('potion')).toBe(false);
+        expect(inv.count('potion')).toBe(0);
+    });
+
+    test('remove fails if not enough items', () => {
+        const inv = new Inventory();
+        inv.add('potion', 1);
+        expect(inv.remove('potion', 5)).toBe(false);
+        expect(inv.count('potion')).toBe(1); // unchanged
+    });
+
+    test('remove fails for missing item', () => {
+        const inv = new Inventory();
+        expect(inv.remove('nonexistent')).toBe(false);
+    });
+
+    test('getAll returns all items', () => {
+        const inv = new Inventory();
+        inv.add('key', 1);
+        inv.add('potion', 3);
+        const all = inv.getAll();
+        expect(all).toHaveLength(2);
+        expect(all).toContainEqual({ itemId: 'key', count: 1 });
+        expect(all).toContainEqual({ itemId: 'potion', count: 3 });
+    });
+
+    test('serialize and deserialize round-trip', () => {
+        const inv = new Inventory();
+        inv.add('key', 1);
+        inv.add('potion', 3);
+
+        const data = inv.serialize();
+        expect(data).toEqual({ key: 1, potion: 3 });
+
+        const inv2 = Inventory.deserialize(data);
+        expect(inv2.count('key')).toBe(1);
+        expect(inv2.count('potion')).toBe(3);
+    });
+
+    test('deserialize handles null', () => {
+        const inv = Inventory.deserialize(null);
+        expect(inv.getAll()).toEqual([]);
+    });
+});

--- a/test/player.test.js
+++ b/test/player.test.js
@@ -216,4 +216,60 @@ describe('Player', () => {
         // Player should NOT have moved (exit blocks when crystals insufficient)
         expect(player.x).toBe(1);
     });
+
+    test('has default facing direction (down) and health', () => {
+        const board = makeBoard([
+            ['w', 'w', 'w'],
+            ['w', 'p', 'w'],
+            ['w', 'w', 'w']
+        ]);
+        const player = new Player(1, 1, board);
+        expect(player.facing).toEqual({ dx: 0, dy: 1 });
+        expect(player.health).toBe(3);
+    });
+
+    test('move updates facing direction', () => {
+        const board = makeBoard([
+            ['w', 'w', 'w', 'w'],
+            ['w', 'p', '.', 'w'],
+            ['w', '.', '.', 'w'],
+            ['w', 'w', 'w', 'w']
+        ]);
+        const player = new Player(1, 1, board);
+
+        player.move(1, 0, {});
+        expect(player.facing).toEqual({ dx: 1, dy: 0 });
+
+        player.move(0, 1, {});
+        expect(player.facing).toEqual({ dx: 0, dy: 1 });
+    });
+
+    test('facing updates even when move is blocked', () => {
+        const board = makeBoard([
+            ['w', 'w', 'w'],
+            ['w', 'p', 'w'],
+            ['w', 'w', 'w']
+        ]);
+        const player = new Player(1, 1, board);
+
+        player.move(-1, 0, {});
+        expect(player.facing).toEqual({ dx: -1, dy: 0 });
+        expect(player.x).toBe(1); // didn't move
+    });
+
+    test('getFacingTile returns correct tile', () => {
+        const board = makeBoard([
+            ['w', 'w', 'w', 'w'],
+            ['w', 'p', '.', 'w'],
+            ['w', 'w', 'w', 'w']
+        ]);
+        const player = new Player(1, 1, board);
+
+        // Default facing is down
+        expect(player.getFacingTile()).toEqual({ x: 1, y: 2 });
+
+        // After moving right, facing is right
+        player.move(1, 0, {});
+        expect(player.getFacingTile()).toEqual({ x: 3, y: 1 });
+    });
 });


### PR DESCRIPTION
## Summary

- Adds a complete entity system as an overlay on the existing tile grid — NPCs, enemies, items, and interactive objects (signs, chests, levers)
- Entities are defined in board JSON under an optional `"entities"` key (fully backward-compatible with existing boards)
- Includes turn-based enemy AI (greedy chase), Space bar interaction, dialogue system with branching choices, and a player inventory that persists across board transitions
- New demo board (Oakvale Village) with all entity types, connected to the existing world graph
- **Canvas-based HUD overlay** showing health hearts (top-left) and inventory items with glyphs (bottom-left), plus a fallback text health display in the game-info bar

### What's included (10 commits):
1. **Entity base class + EntityRegistry** — per-board spatial index with position lookups
2. **Entity subtypes + factory** — NPC (cycling dialogue), Enemy (chase AI + combat), Item (pickup), InteractiveObject (sign/chest/lever)
3. **Inventory system** — add/remove/has/count with serialize/deserialize for save games
4. **Player facing direction + health** — facing updates on every move attempt; `getFacingTile()` for interaction targeting
5. **Entity rendering layer** — colored rectangles with glyphs rendered between tiles and player, plus facing indicator
6. **Dialogue system** — sequential and branching nodes, captures input when active (arrows/Enter/Escape)
7. **Game loop integration** — entity loading, Space=interact, blocking entities, turn-based updates, enemy collision damage
8. **Demo board + integration tests** — Oakvale Village with NPC elder, slime enemy, health potion, sign, and treasure chest
9. **HUD renderer** — canvas-based overlay with health hearts (❤️/🖤) top-left and inventory glyphs+counts bottom-left; `Player.maxHealth` property added
10. **Game-info bar health display** — `<span id="health-display">` in index.html, `updateGameInfo()` shows "Health: X/Y" as text fallback

## Test plan

- [x] `npm test` passes — 152 tests across 14 files (70 new tests)
- [x] `npm start` — world mode loads, entities visible on clearing and village boards
- [x] Walk to NPC → Space → dialogue appears → Enter advances → dialogue closes
- [x] Enemy chases player each turn, combat works on Space (2 hits to defeat slime)
- [x] Health hearts visible top-left (3 red hearts at full health)
- [x] Take damage from enemy → hearts update (red → black for lost HP)
- [x] Pick up item → inventory appears bottom-left with glyph + count
- [ ] Inventory persists across board transitions, HUD updates accordingly
- [ ] Minimap (top-right) still renders correctly, no overlap with HUD
- [ ] Blocking entities (NPC, enemy, chest) prevent walk-through; items don't block
- [ ] Legacy mode (no world.json) — HUD shows health only, no inventory, no errors
- [ ] Boards without `"entities"` key work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)